### PR TITLE
DataSourceVO access private variable in Generic type T extends DataSourceVO

### DIFF
--- a/Core/src/com/serotonin/m2m2/vo/dataSource/DataSourceVO.java
+++ b/Core/src/com/serotonin/m2m2/vo/dataSource/DataSourceVO.java
@@ -230,12 +230,12 @@ abstract public class DataSourceVO<T extends DataSourceVO<?>> implements Seriali
 
     @Override
     public final void addPropertyChanges(List<TranslatableMessage> list, T from) {
-        AuditEventType.maybeAddPropertyChangeMessage(list, "dsEdit.head.name", from.name, name);
-        AuditEventType.maybeAddPropertyChangeMessage(list, "common.xid", from.xid, xid);
-        AuditEventType.maybeAddPropertyChangeMessage(list, "common.enabled", from.enabled, enabled);
-        AuditEventType.maybeAddPropertyChangeMessage(list, "dsEdit.logging.purgeOverride", from.purgeOverride,
+        AuditEventType.maybeAddPropertyChangeMessage(list, "dsEdit.head.name", from.getName(), name);
+        AuditEventType.maybeAddPropertyChangeMessage(list, "common.xid", from.getXid(), xid);
+        AuditEventType.maybeAddPropertyChangeMessage(list, "common.enabled", from.isEnabled(), enabled);
+        AuditEventType.maybeAddPropertyChangeMessage(list, "dsEdit.logging.purgeOverride", from.isPurgeOverride(),
                 purgeOverride);
-        AuditEventType.maybeAddPeriodChangeMessage(list, "dsEdit.logging.purge", from.purgeType, from.purgePeriod,
+        AuditEventType.maybeAddPeriodChangeMessage(list, "dsEdit.logging.purge", from.getPurgeType(), from.getPurgePeriod(),
                 purgeType, purgePeriod);
 
         addPropertyChangesImpl(list, from);


### PR DESCRIPTION
There is a change from Java 6 to 7 where access to private member of Generic  classes are no longer allowed. 

See this stackoverflow post: http://stackoverflow.com/questions/10782876/changes-in-access-of-variables-for-generic-classes-in-java-7

Update DataSourceVO to use getter methods
