### PR TITLE
Only add properties to H2 url if they dont exist

### DIFF
--- a/Core/src/com/serotonin/m2m2/db/H2Proxy.java
+++ b/Core/src/com/serotonin/m2m2/db/H2Proxy.java
@@ -77,7 +77,12 @@ public class H2Proxy extends DatabaseProxy {
     private String getUrl(String propertyPrefix) {
         String url = Common.envProps.getString(propertyPrefix + "db.url");
         url = StringUtils.replaceMacros(url, System.getProperties());
-        url += ";DB_CLOSE_ON_EXIT=FALSE;MV_STORE=FALSE";
+        if (!url.contains(";DB_CLOSE_ON_EXIT=")) {
+        	url += ";DB_CLOSE_ON_EXIT=FALSE";
+        }
+        if (!url.contains(";MV_STORE=")) {
+        	url += ";MV_STORE=FALSE";
+        }
         return url;
     }
 


### PR DESCRIPTION
Only add properties to H2 url if they dont exist, allows user to set their own options
