### PR TITLE
Use COUNT(DISTINCT id) for getting row count

### DIFF
--- a/Core/src/com/infiniteautomation/mango/db/query/SQLStatement.java
+++ b/Core/src/com/infiniteautomation/mango/db/query/SQLStatement.java
@@ -153,11 +153,7 @@ public class SQLStatement {
 	
 	public String getCountSql(){
 		StringBuilder sb = new StringBuilder(this.countSql);
-		
-		//Apply Joins
-		if(this.joins != null)
-			sb.append(joins);
-		
+
 		//Apply Where Clause
 		if(this.appliedWhere)
 			sb.append(this.countWhere);

--- a/Core/src/com/infiniteautomation/mango/db/query/SQLSubQuery.java
+++ b/Core/src/com/infiniteautomation/mango/db/query/SQLSubQuery.java
@@ -111,12 +111,7 @@ public class SQLSubQuery extends SQLStatement{
 			baseCount.append(this.tablePrefix);
 			baseCount.append(SPACE);
 		}
-		
-		if(this.baseSelect.joins != null){
-			baseCount.append(this.baseSelect.joins);
-			baseCount.append(SPACE);
-		}
-		
+
 		if(this.baseSelect.appliedWhere)
 			baseCount.append(this.baseSelect.selectWhere);		
 		

--- a/Core/src/com/serotonin/m2m2/db/dao/AbstractBasicDao.java
+++ b/Core/src/com/serotonin/m2m2/db/dao/AbstractBasicDao.java
@@ -169,9 +169,10 @@ public abstract class AbstractBasicDao<T> extends BaseDao {
         //Add the table prefix to the queries if necessary
         EXTRA_SQL = extraSQL;
         SELECT_ALL_BASE = selectAll + " FROM ";
-        COUNT_BASE = "SELECT COUNT(*) FROM ";
         
         if (this.tablePrefix.equals("")) {
+            COUNT_BASE = "SELECT COUNT(DISTINCT id) FROM ";
+            
             if (extraSQL != null)
                 SELECT_ALL = selectAll + " FROM " + tableName + " " + extraSQL;
             else
@@ -192,12 +193,14 @@ public abstract class AbstractBasicDao<T> extends BaseDao {
             UPDATE = update + " WHERE id=?";
             DELETE = "DELETE FROM " + tableName + " WHERE id=?";
             if (extraSQL != null)
-                COUNT = "SELECT COUNT(*) FROM " + tableName + " " + extraSQL;
+                COUNT = "SELECT COUNT(DISTINCT id) FROM " + tableName + " " + extraSQL;
             else
-                COUNT = "SELECT COUNT(*) FROM " + tableName;
+                COUNT = "SELECT COUNT(DISTINCT id) FROM " + tableName;
 
         }
         else {
+            COUNT_BASE = "SELECT COUNT(DISTINCT " + tablePrefix +".id) FROM ";
+            
             //this.tablePrefix will end in a . where the local tablePrefix shouldn't
             if (extraSQL != null)
                 SELECT_ALL = selectAll + " FROM " + tableName + " AS " + tablePrefix + " " + extraSQL;
@@ -219,9 +222,9 @@ public abstract class AbstractBasicDao<T> extends BaseDao {
             UPDATE = update + " WHERE id=?";
             DELETE = "DELETE FROM " + tableName + " WHERE id=?";
             if (extraSQL != null)
-                COUNT = "SELECT COUNT(*) FROM " + tableName + " AS " + tablePrefix + " " + extraSQL;
+                COUNT = "SELECT COUNT(DISTINCT " + tablePrefix +".id) FROM " + tableName + " AS " + tablePrefix + " " + extraSQL;
             else
-                COUNT = "SELECT COUNT(*) FROM " + tableName + " AS " + tablePrefix;
+                COUNT = "SELECT COUNT(DISTINCT " + tablePrefix +".id) FROM " + tableName + " AS " + tablePrefix;
         }
 
         //Create the Update and Insert property types lists

--- a/Core/src/com/serotonin/m2m2/db/dao/DataPointDao.java
+++ b/Core/src/com/serotonin/m2m2/db/dao/DataPointDao.java
@@ -395,7 +395,7 @@ public class DataPointDao extends AbstractDao<DataPointVO> {
     }
 
     public int countPointsForDataSourceType(String dataSourceType) {
-        return ejt.queryForInt("SELECT count(*) FROM dataPoints dp LEFT JOIN dataSources ds ON dp.dataSourceId=ds.id "
+        return ejt.queryForInt("SELECT count(DISTINCT dp.id) FROM dataPoints dp LEFT JOIN dataSources ds ON dp.dataSourceId=ds.id "
                 + "WHERE ds.dataSourceType=?", new Object[] { dataSourceType }, 0);
     }
 


### PR DESCRIPTION
Much faster than COUNT(*) for large data point tables - 3.2s down to sub 100ms for 100,000 data points.

Fairly significant change though so needs some thorough review. Things to look at -
* I've removed joins for the count calls, will this affect anything
* Check every VO has an id column which is the primary key/unique and is non-null
