### PR TITLE
Dependency versioning

### DIFF
--- a/Core/.classpath
+++ b/Core/.classpath
@@ -28,5 +28,11 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="src" output="maven-target/classes" path="maven-target/generated-sources/java-templates">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="maven-target/classes"/>
 </classpath>

--- a/Core/.settings/org.eclipse.core.resources.prefs
+++ b/Core/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,5 @@
 eclipse.preferences.version=1
+encoding//maven-target/generated-sources/java-templates=UTF-8
 encoding/<project>=UTF-8
 encoding/LICENSE=UTF-8
 encoding/RELEASE-NOTES=UTF-8

--- a/Core/.settings/org.eclipse.wst.common.component
+++ b/Core/.settings/org.eclipse.wst.common.component
@@ -7,6 +7,7 @@
         <wb-resource deploy-path="/WEB-INF/classes" source-path="/src-unit"/>
         <wb-resource deploy-path="/WEB-INF/classes" source-path="/overrides/classes"/>
         <wb-resource deploy-path="/WEB-INF/classes" source-path="/src-patch"/>
+        <wb-resource deploy-path="/WEB-INF/classes" source-path="/maven-target/generated-sources/java-templates"/>
         <property name="context-root" value="Core"/>
         <property name="java-output-path" value="/Core/maven-target/classes"/>
     </wb-module>

--- a/Core/java-templates/com/infiniteautomation/mango/CompiledCoreVersion.java
+++ b/Core/java-templates/com/infiniteautomation/mango/CompiledCoreVersion.java
@@ -1,0 +1,13 @@
+/**
+ * Copyright (C) 2017 Infinite Automation Software. All rights reserved.
+ */
+package com.infiniteautomation.mango;
+
+import com.github.zafarkhaja.semver.Version;
+
+/**
+ * @author Jared Wiltshire
+ */
+public class CompiledCoreVersion {
+    public static final Version VERSION = Version.valueOf("${project.version}");
+}

--- a/Core/pom.xml
+++ b/Core/pom.xml
@@ -148,6 +148,21 @@
                     <useBaseVersion>false</useBaseVersion>
                 </configuration>
             </plugin>
+            <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>templating-maven-plugin</artifactId>
+              <executions>
+                <execution>
+                    <id>filtering-java-templates</id>
+                    <goals>
+                        <goal>filter-sources</goal>
+                    </goals>
+                    <configuration>
+                      <sourceDirectory>${project.basedir}/java-templates</sourceDirectory>
+                    </configuration>
+                </execution>
+              </executions>
+            </plugin>
 		</plugins>
 		<pluginManagement>
 			<plugins>

--- a/Core/pom.xml
+++ b/Core/pom.xml
@@ -629,5 +629,10 @@
 		  <artifactId>jjwt</artifactId>
 		  <version>0.7.0</version>
 		</dependency>
+		<dependency>
+		  <groupId>com.github.zafarkhaja</groupId>
+		  <artifactId>java-semver</artifactId>
+		  <version>0.9.0</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/Core/src/com/serotonin/m2m2/Common.java
+++ b/Core/src/com/serotonin/m2m2/Common.java
@@ -44,6 +44,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCrypt;
 
 import com.github.zafarkhaja.semver.Version;
+import com.infiniteautomation.mango.CompiledCoreVersion;
 import com.infiniteautomation.mango.io.serial.SerialPortManager;
 import com.infiniteautomation.mango.monitor.MonitoredValues;
 import com.serotonin.ShouldNeverHappenException;
@@ -151,25 +152,25 @@ public class Common {
      * particular to the schema, but is still required to update the system settings so that the database has the
      * correct version.
      */
-    
-    public static final Version COMPILED_CORE_VERSION = Version.valueOf("3.0.3-SNAPSHOT");
-    
+
     public static final Version getVersion() {
         return CoreVersion.INSTANCE.version;
     }
     
     private enum CoreVersion {
-        INSTANCE(COMPILED_CORE_VERSION);
+        INSTANCE();
         final Version version;
         
-        CoreVersion(Version version) {
+        CoreVersion() {
+            Version version = CompiledCoreVersion.VERSION;
+            
             try {
                 version = loadCoreVersionFromReleaseProperties(version);
             } catch (Throwable t) {}
             
             // check for possible license subversion
-            if (version.getMajorVersion() != COMPILED_CORE_VERSION.getMajorVersion()) {
-                throw new RuntimeException("Version from release.properties does not match compiled major version " + COMPILED_CORE_VERSION.getMajorVersion());
+            if (version.getMajorVersion() != CompiledCoreVersion.VERSION.getMajorVersion()) {
+                throw new RuntimeException("Version from release.properties does not match compiled major version " + CompiledCoreVersion.VERSION.getMajorVersion());
             }
             
             this.version = version;

--- a/Core/src/com/serotonin/m2m2/Common.java
+++ b/Core/src/com/serotonin/m2m2/Common.java
@@ -5,6 +5,8 @@
 package com.serotonin.m2m2;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -14,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Properties;
 import java.util.TimeZone;
 import java.util.UUID;
 import java.util.regex.Matcher;
@@ -40,6 +43,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCrypt;
 
+import com.github.zafarkhaja.semver.Version;
 import com.infiniteautomation.mango.io.serial.SerialPortManager;
 import com.infiniteautomation.mango.monitor.MonitoredValues;
 import com.serotonin.ShouldNeverHappenException;
@@ -54,7 +58,7 @@ import com.serotonin.m2m2.rt.EventManager;
 import com.serotonin.m2m2.rt.RuntimeManager;
 import com.serotonin.m2m2.rt.maint.BackgroundProcessing;
 import com.serotonin.m2m2.rt.maint.work.WorkItem;
-import com.serotonin.m2m2.shared.VersionData;
+import com.serotonin.m2m2.shared.ModuleUtils;
 import com.serotonin.m2m2.util.BackgroundContext;
 import com.serotonin.m2m2.util.DocumentationManifest;
 import com.serotonin.m2m2.util.ExportCodes;
@@ -147,20 +151,43 @@ public class Common {
      * particular to the schema, but is still required to update the system settings so that the database has the
      * correct version.
      */
-    public static final VersionData getVersion() {
-        return new VersionData(getMajorVersion(), getMinorVersion(), getMicroVersion());
+    
+    public static final Version COMPILED_CORE_VERSION = Version.valueOf("3.0.3-SNAPSHOT");
+    
+    public static final Version getVersion() {
+        return CoreVersion.INSTANCE.version;
+    }
+    
+    private enum CoreVersion {
+        INSTANCE(COMPILED_CORE_VERSION);
+        final Version version;
+        
+        CoreVersion(Version version) {
+            try {
+                version = loadCoreVersionFromReleaseProperties(version);
+            } catch (Throwable t) {}
+            this.version = version;
+        }
     }
 
-    public static final int getMajorVersion() {
-        return 3;
-    }
+    private static final Version loadCoreVersionFromReleaseProperties(Version version) {
+        Properties props = new Properties();
+        File propFile = new File(Common.MA_HOME + File.separator + "release.properties");
 
-    public static final int getMinorVersion() {
-        return 1;
-    }
+        if (propFile.exists()) {
+            try (InputStream in = new FileInputStream(propFile)) {
+                props.load(in);
+            } catch (Exception e1) { }
 
-    public static final int getMicroVersion() {
-        return 0;
+            String versionStr = props.getProperty(ModuleUtils.Constants.PROP_VERSION);
+            if (versionStr != null) {
+                try {
+                    version = Version.valueOf(versionStr);
+                } catch (com.github.zafarkhaja.semver.ParseException e) { }
+            }
+        }
+        
+        return version;
     }
 
     public static final int getDatabaseSchemaVersion() {

--- a/Core/src/com/serotonin/m2m2/Common.java
+++ b/Core/src/com/serotonin/m2m2/Common.java
@@ -166,6 +166,12 @@ public class Common {
             try {
                 version = loadCoreVersionFromReleaseProperties(version);
             } catch (Throwable t) {}
+            
+            // check for possible license subversion
+            if (version.getMajorVersion() != COMPILED_CORE_VERSION.getMajorVersion()) {
+                throw new RuntimeException("Version from release.properties does not match compiled major version " + COMPILED_CORE_VERSION.getMajorVersion());
+            }
+            
             this.version = version;
         }
     }
@@ -180,10 +186,16 @@ public class Common {
             } catch (Exception e1) { }
 
             String versionStr = props.getProperty(ModuleUtils.Constants.PROP_VERSION);
+            String buildNumberStr = props.getProperty(ModuleUtils.Constants.BUILD_NUMBER);
+            
             if (versionStr != null) {
                 try {
                     version = Version.valueOf(versionStr);
                 } catch (com.github.zafarkhaja.semver.ParseException e) { }
+            }
+            
+            if (buildNumberStr != null) {
+                version = version.setBuildMetadata(buildNumberStr);
             }
         }
         

--- a/Core/src/com/serotonin/m2m2/module/Module.java
+++ b/Core/src/com/serotonin/m2m2/module/Module.java
@@ -11,6 +11,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import com.github.zafarkhaja.semver.Version;
 import com.serotonin.m2m2.Common;
 import com.serotonin.m2m2.Constants;
 import com.serotonin.m2m2.UpgradeVersionState;
@@ -56,7 +57,7 @@ public class Module {
     }
 
     private final String name;
-    private final String version;
+    private final Version version;
     private String licenseType;
     private final TranslatableMessage description;
     private final String vendor;
@@ -70,8 +71,6 @@ public class Module {
     private final Set<String> locales = new HashSet<>();
     private String graphics;
     private String emailTemplates;
-    private final int versionState;
-    private final int buildNumber;
     private final boolean signed;
 
     /**
@@ -83,8 +82,8 @@ public class Module {
      * @param vendor
      * @param vendorUrl
      */
-    public Module(String name, String version, TranslatableMessage description, String vendor, String vendorUrl,
-            String dependencies, int loadOrder, int versionState, int buildNumber, boolean signed) {
+    public Module(String name, Version version, TranslatableMessage description, String vendor, String vendorUrl,
+            String dependencies, int loadOrder, boolean signed) {
         this.name = name;
         this.version = version;
         this.description = description;
@@ -92,8 +91,6 @@ public class Module {
         this.vendorUrl = vendorUrl;
         this.dependencies = dependencies;
         this.loadOrder = loadOrder;
-        this.versionState = versionState;
-        this.buildNumber = buildNumber;
         this.signed = signed;
     }
 
@@ -211,16 +208,12 @@ public class Module {
     /**
      * @return the module's version
      */
-    public String getVersion() {
+    public Version getVersion() {
         return version;
     }
     
-    public int getVersionState() {
-    	return versionState;
-    }
-    
-    public String getVersionAndState() {
-    	return version + "-" + versionState;
+    public String getNormalVersion() {
+        return version.getNormalVersion();
     }
 
     public String getLicenseType() {
@@ -251,8 +244,8 @@ public class Module {
         return loadOrder;
     }
     
-    public int getBuildNumber(){
-    	return this.buildNumber;
+    public String getBuildNumber(){
+    	return this.version.getBuildMetadata();
     }
     
     public boolean isSigned() {

--- a/Core/src/com/serotonin/m2m2/module/ModuleRegistry.java
+++ b/Core/src/com/serotonin/m2m2/module/ModuleRegistry.java
@@ -4,9 +4,6 @@
  */
 package com.serotonin.m2m2.module;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -15,7 +12,6 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -28,7 +24,6 @@ import org.springframework.web.servlet.mvc.Controller;
 import com.serotonin.NotImplementedException;
 import com.serotonin.m2m2.Common;
 import com.serotonin.m2m2.ICoreLicense;
-import com.serotonin.m2m2.UpgradeVersionState;
 import com.serotonin.m2m2.db.dao.SystemSettingsDao;
 import com.serotonin.m2m2.i18n.TranslatableMessage;
 import com.serotonin.m2m2.module.MenuItemDefinition.Visibility;
@@ -88,7 +83,6 @@ import com.serotonin.m2m2.module.definitions.settings.TimezoneInfoDefinition;
 import com.serotonin.m2m2.module.license.LicenseEnforcement;
 import com.serotonin.m2m2.rt.event.type.AuditEventTypeSettingsListenerDefinition;
 import com.serotonin.m2m2.rt.event.type.SystemEventTypeSettingsListenerDefinition;
-import com.serotonin.m2m2.shared.DependencyData;
 import com.serotonin.m2m2.vo.User;
 import com.serotonin.m2m2.vo.permission.PermissionException;
 import com.serotonin.m2m2.vo.permission.Permissions;
@@ -119,7 +113,7 @@ public class ModuleRegistry {
 	
     private static final Object LOCK = new Object();
     private static final Map<String, Module> MODULES = new LinkedHashMap<String, Module>();
-    private static final Map<String, DependencyData> MISSING_DEPENDENCIES = new LinkedHashMap<String, DependencyData>();
+    private static final Map<String, String> MISSING_DEPENDENCIES = new LinkedHashMap<>();
     private static final List<Module> UNLOADED_MODULES = new CopyOnWriteArrayList<>();
 
     private static Map<String, DataSourceDefinition> DATA_SOURCE_DEFINITIONS;
@@ -151,30 +145,8 @@ public class ModuleRegistry {
      * @return
      */
     public static Module getCoreModule(){
-    	
-    	Properties props = new Properties();
-    	File propFile = new File(Common.MA_HOME + File.separator + "release.properties");
-        int versionState = UpgradeVersionState.DEVELOPMENT;
-        int buildNumber = -1;
-        if(propFile.exists()) {
-	        //InputStream in = new FileInputStream(propFile);
-	        try(InputStream in = new FileInputStream(propFile)){
-	        	props.load(in);
-	        } catch (Exception e1) { }
-	        String buildNumberStr = props.getProperty("buildNumber");
-	        String currentVersionState = props.getProperty("versionState");
-	        try {
-	        	if(currentVersionState != null)
-	        		versionState = Integer.valueOf(currentVersionState);
-	        } catch(NumberFormatException e) { }
-	        try {
-	        	if(buildNumberStr != null)
-	        		buildNumber = Integer.valueOf(buildNumberStr);
-	        } catch(NumberFormatException e) { }
-        }
-    	
-        Module core = new Module("core", Common.getVersion().getFullString(), new TranslatableMessage("modules.core.description"),
-                "Infinite Automation Systems.", "http://infiniteautomation.com", null, -1, versionState, buildNumber, false);
+        Module core = new Module("core", Common.getVersion(), new TranslatableMessage("modules.core.description"),
+                "Infinite Automation Systems.", "http://infiniteautomation.com", null, -1, false);
 
         if(Common.isInvalid())
         	core.setLicenseType("Invalid");
@@ -233,7 +205,7 @@ public class ModuleRegistry {
      * @param moduleName
      * @param version
      */
-    public static void addMissingDependency(String moduleName, DependencyData version){
+    public static void addMissingDependency(String moduleName, String version){
     	MISSING_DEPENDENCIES.put(moduleName, version);
     }
     
@@ -243,7 +215,7 @@ public class ModuleRegistry {
      * Users must not modify this list.
      * @return
      */
-    public static Map<String, DependencyData> getMissingDependencies(){
+    public static Map<String, String> getMissingDependencies(){
     	return MISSING_DEPENDENCIES;
     }
     

--- a/Core/src/com/serotonin/m2m2/web/dwr/ModulesDwr.java
+++ b/Core/src/com/serotonin/m2m2/web/dwr/ModulesDwr.java
@@ -27,6 +27,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 
+import com.github.zafarkhaja.semver.Version;
 import com.serotonin.ShouldNeverHappenException;
 import com.serotonin.db.pair.StringStringPair;
 import com.serotonin.json.JsonException;
@@ -168,7 +169,9 @@ public class ModulesDwr extends BaseDwr {
             Map<String, String> jsonModules = new HashMap<>();
             json.put("modules", jsonModules);
 
-            jsonModules.put("core", Common.getVersion().getFullString());
+            Version coreVersion = Common.getVersion();
+            
+            jsonModules.put("core", coreVersion.toString());
             for (StringStringPair module : modules)
                 jsonModules.put(module.getKey(), module.getValue());
 
@@ -326,13 +329,14 @@ public class ModulesDwr extends BaseDwr {
         Map<String, String> jsonModules = new HashMap<>();
         json.put("modules", jsonModules);
 
-        jsonModules.put("core", Common.getVersion().getFullString());
+        Version coreVersion = Common.getVersion();
+        jsonModules.put("core", coreVersion.toString());
         for (Module module : modules)
-            jsonModules.put(module.getName(), module.getVersionAndState());
+            jsonModules.put(module.getName(), module.getVersion().toString());
         
         //Add in the unloaded modules so we don't re-download them if we don't have to
         for(Module module : ModuleRegistry.getUnloadedModules())
-        	jsonModules.put(module.getName(), module.getVersionAndState());
+        	jsonModules.put(module.getName(), module.getVersion().toString());
 
         StringWriter stringWriter = new StringWriter();
         new JsonWriter(Common.JSON_CONTEXT, stringWriter).writeObject(json);

--- a/Core/src/com/serotonin/m2m2/web/mvc/controller/ModulesController.java
+++ b/Core/src/com/serotonin/m2m2/web/mvc/controller/ModulesController.java
@@ -67,13 +67,7 @@ public class ModulesController implements UrlHandler {
         json.put("modules", jsonModules);
 
         for (Module module : modules) {
-            if (module.getName().equals("core")) {
-                //Don't add that core module as it might have the build number in the version
-                jsonModules.put("core", Common.getVersion().getFullString());
-            }
-            else {
-                jsonModules.put(module.getName(), module.getVersion());
-            }
+            jsonModules.put(module.getName(), module.getVersion().toString());
         }
 
         try {

--- a/pom.xml
+++ b/pom.xml
@@ -242,6 +242,11 @@
               <scmVersionType>branch</scmVersionType>
           </configuration>
          </plugin>
+         <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>templating-maven-plugin</artifactId>
+            <version>1.0.0</version>
+         </plugin>
         </plugins>
     </pluginManagement>
     <plugins>


### PR DESCRIPTION
I have reworked the version and dependency information in Mango, it now uses the [Java SemVer library](https://github.com/zafarkhaja/jsemver)

Version state is no longer a thing, it has been replaced by suffixes on the version number. e.g.
3.0.2-SNAPSHOT or 3.0.2-alpha.0 or 3.0.2-rc.1+1234 where 1234 is the build number

There is a new generated class called CompiledCoreVersion which is automatically filled with the version from the pom.xml
The build number is read from the module.properties or release.properties file and appended to the version.

The coreVersion property and the dependencies properties now use the range syntax from here https://github.com/zafarkhaja/jsemver#external-dsl

The store should use the same SemVer library to parse the version strings and compare it to the versions in the store to determine if upgrades are available. If a person changes the release type of a module via the store web interface it should modify the version property in the module file. i.e.
* DEVELOPMENT - "-SNAPSHOT"
* ALPHA - "-alpha.0"
* BETA - "-beta.0"
* RELEASE_CANDIDATE - "-rc.0"
* PRODUCTION - no suffix

### Notes for modifying module.properties or release.properties
* version=${noSnapshotVer} =>version=${project.version}
* dependencies=mangoUI-3.0,modbus-3.0+ => dependencies=mangoUI:3.0,modbus:3.0
* versionState=${mango.build.versionState} => remove it!