### PR TITLE
Notify websocket of original xid when updating xid

### DIFF
--- a/Core/src/com/serotonin/m2m2/db/dao/AbstractBasicDao.java
+++ b/Core/src/com/serotonin/m2m2/db/dao/AbstractBasicDao.java
@@ -435,35 +435,16 @@ public abstract class AbstractBasicDao<T extends AbstractBasicVO> extends BaseDa
 	}
 
 	public void delete(int id) {
-		T vo = get(id);
-		if (vo != null) {
-			ejt.update(DELETE, vo.getId());
-			if(this.countMonitor != null)
-				this.countMonitor.decrement();
-		}
-		if(handler != null)
-			handler.notify("delete", vo, null);
+		delete(id, null);
 	}
 
 	public void delete(int id, String initiatorId) {
 		T vo = get(id);
-		if (vo != null) {
-			ejt.update(DELETE, vo.getId());
-			if(this.countMonitor != null)
-				this.countMonitor.decrement();
-		}
-		if(handler != null)
-			handler.notify("delete", vo, initiatorId);
+		delete(vo, initiatorId);
 	}
 
 	public void delete(T vo) {
-		if (vo != null) {
-			ejt.update(DELETE, vo.getId());
-			if(this.countMonitor != null)
-				this.countMonitor.decrement();
-		}
-		if(handler != null)
-			handler.notify("delete", vo, null);
+		delete(vo, null);
 	}
 
 	public void delete(T vo, String initiatorId) {
@@ -483,11 +464,7 @@ public abstract class AbstractBasicDao<T extends AbstractBasicVO> extends BaseDa
 	 *            to save
 	 */
 	public void save(T vo) {
-		if (vo.getId() == Common.NEW_ID) {
-			insert(vo);
-		} else {
-			update(vo);
-		}
+	    save(vo, null);
 	}
 
 	/**
@@ -496,11 +473,11 @@ public abstract class AbstractBasicDao<T extends AbstractBasicVO> extends BaseDa
 	 * @param initiatorId
 	 */
 	public void save(T vo, String initiatorId) {
-		if (vo.getId() == Common.NEW_ID) {
-			insert(vo, initiatorId);
-		} else {
-			update(vo, initiatorId);
-		}
+	    if (vo.getId() == Common.NEW_ID) {
+            insert(vo, initiatorId);
+        } else {
+            update(vo, initiatorId);
+        }
 	}
 
 	/**
@@ -510,16 +487,7 @@ public abstract class AbstractBasicDao<T extends AbstractBasicVO> extends BaseDa
 	 *            to insert
 	 */
 	protected void insert(T vo) {
-		int id = -1;
-		if (insertStatementPropertyTypes == null)
-			id = ejt.doInsert(INSERT, voToObjectArray(vo));
-		else
-			id = ejt.doInsert(INSERT, voToObjectArray(vo), insertStatementPropertyTypes);
-		vo.setId(id);
-		if(handler != null)
-			handler.notify("add", vo, null);
-		if(this.countMonitor != null)
-			this.countMonitor.increment();
+		insert(vo, null);
 	}
 
 	/**
@@ -547,16 +515,7 @@ public abstract class AbstractBasicDao<T extends AbstractBasicVO> extends BaseDa
 	 *            to update
 	 */
 	protected void update(T vo) {
-		List<Object> list = new ArrayList<>();
-		list.addAll(Arrays.asList(voToObjectArray(vo)));
-		list.add(vo.getId());
-
-		if (updateStatementPropertyTypes == null)
-			ejt.update(UPDATE, list.toArray());
-		else
-			ejt.update(UPDATE, list.toArray(), updateStatementPropertyTypes);
-		if(handler != null)
-			handler.notify("update", vo, null);
+        update(vo, null, null);
 	}
 
 	/**
@@ -565,17 +524,27 @@ public abstract class AbstractBasicDao<T extends AbstractBasicVO> extends BaseDa
 	 * @param initiatorId
 	 */
 	protected void update(T vo, String initiatorId) {
-		List<Object> list = new ArrayList<>();
-		list.addAll(Arrays.asList(voToObjectArray(vo)));
-		list.add(vo.getId());
-
-		if (updateStatementPropertyTypes == null)
-			ejt.update(UPDATE, list.toArray());
-		else
-			ejt.update(UPDATE, list.toArray(), updateStatementPropertyTypes);
-		if(handler != null)
-			handler.notify("update", vo, initiatorId);
+		update(vo, initiatorId, null);
 	}
+	
+	/**
+     * 
+     * @param vo
+     * @param initiatorId
+     * @param originalXid XID of object prior to update
+     */
+    protected void update(T vo, String initiatorId, String originalXid) {
+        List<Object> list = new ArrayList<>();
+        list.addAll(Arrays.asList(voToObjectArray(vo)));
+        list.add(vo.getId());
+
+        if (updateStatementPropertyTypes == null)
+            ejt.update(UPDATE, list.toArray());
+        else
+            ejt.update(UPDATE, list.toArray(), updateStatementPropertyTypes);
+        if(handler != null)
+            handler.notify("update", vo, initiatorId, originalXid);
+    }
 
 	/**
 	 * Return a VO with FKs populated

--- a/Core/src/com/serotonin/m2m2/db/dao/AbstractDao.java
+++ b/Core/src/com/serotonin/m2m2/db/dao/AbstractDao.java
@@ -277,42 +277,25 @@ public abstract class AbstractDao<T extends AbstractVO<?>> extends AbstractBasic
         sql = applyRange(sql, args, offset, limit);
         return query(sql, args.toArray(), getRowMapper());
     }
-
-    /**
-     * Persist the vo or if it already exists update it
-     * 
-     * @param vo
-     *            to save
-     */
+    
+    // TODO remove these overridden methods in 3.3, needed in 3.2 for API compatibility
     @Override
     public void save(T vo) {
-    	save(vo, null);
-    }
-
-	/**
-	 * 
-	 * @param vo
-	 * @param initiatorId
-	 */
-    public void save(T vo, String initiatorId) {
-        if (vo.getId() == Common.NEW_ID) {
-            insert(vo, initiatorId);
-        }
-        else {
-            update(vo, initiatorId);
-        }
+        save(vo, null);
     }
     
-    /**
-     * Insert a new vo and assign the ID
-     * 
-     * @param vo
-     *            to insert
-     */
+    // TODO remove these overridden methods in 3.3, needed in 3.2 for API compatibility
+    @Override
+    public void save(T vo, String initiatorId) {
+        super.save(vo, initiatorId);
+    }
+    
+    // TODO remove these overridden methods in 3.3, needed in 3.2 for API compatibility
     @Override
     protected void insert(T vo) {
-    	insert(vo, null);
+        insert(vo, null);
     }
+
     @Override
     protected void insert(T vo, String initiatorId) {
         if (vo.getXid() == null) {
@@ -320,22 +303,27 @@ public abstract class AbstractDao<T extends AbstractVO<?>> extends AbstractBasic
         }
         super.insert(vo, initiatorId);
         AuditEventType.raiseAddedEvent(this.typeName, vo);
-    }    
-
-    /**
-     * Update a vo
-     * 
-     * @param vo
-     *            to update
-     */
+    }
+    
+    // TODO remove these overridden methods in 3.3, needed in 3.2 for API compatibility
     @Override
     protected void update(T vo) {
-    	update(vo, null);
+        update(vo, null, null);
     }
+
+    // TODO remove these overridden methods in 3.3, needed in 3.2 for API compatibility
     @Override
-    protected void update(T vo, String initiatorId){
+    protected void update(T vo, String initiatorId) {
+        update(vo, initiatorId, null);
+    }
+
+    @Override
+    protected void update(T vo, String initiatorId, String originalXid) {
         T old = get(vo.getId());
-        super.update(vo);
+        if (originalXid == null) {
+            originalXid = old.getXid();
+        }
+        super.update(vo, initiatorId, originalXid);
         AuditEventType.raiseChangedEvent(this.typeName, old, vo);
     }
 

--- a/Core/src/com/serotonin/m2m2/web/mvc/websocket/DaoNotificationModel.java
+++ b/Core/src/com/serotonin/m2m2/web/mvc/websocket/DaoNotificationModel.java
@@ -30,13 +30,24 @@ public class DaoNotificationModel {
     @JsonProperty
     String initiatorId;
     
+    /**
+     * Contains the xid of the object prior to an update (XIDs can be changed)
+     */
+    @JsonProperty
+    String originalXid;
+    
     public DaoNotificationModel() {
     }
     
     public DaoNotificationModel(String action, Object object, String initiatorId) {
+        this(action, object, initiatorId, null);
+    }
+    
+    public DaoNotificationModel(String action, Object object, String initiatorId, String originalXid) {
         this.action = action;
         this.object = object;
         this.initiatorId = initiatorId;
+        this.originalXid = originalXid;
     }
 
     public String getAction() {
@@ -61,5 +72,13 @@ public class DaoNotificationModel {
 
     public void setInitiatorId(String initiatorId) {
         this.initiatorId = initiatorId;
+    }
+
+    public String getOriginalXid() {
+        return originalXid;
+    }
+
+    public void setOriginalXid(String originalXid) {
+        this.originalXid = originalXid;
     }
 }


### PR DESCRIPTION
Currently websockets are notified on create/update/delete events.

It is possible to change an item's XID and when a websocket listener receives an update event there is no way to tell what it's previous XID was. This is important to know as the new UI predominately uses the XID to track items.

This change modifies the abstract DAOs so that they send the previous XID to the websocket. I also removed some redundant code while keeping API compatibility.