### PR TITLE
Adding basic usage tracking for data points and sources

### DIFF
--- a/Core/src/com/infiniteautomation/mango/util/usage/DataPointUsageStatistics.java
+++ b/Core/src/com/infiniteautomation/mango/util/usage/DataPointUsageStatistics.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2019  Infinite Automation Software. All rights reserved.
+ */
+package com.infiniteautomation.mango.util.usage;
+
+/**
+ * Statistics on how data points are used in this system
+ * 
+ * @author Terry Packer
+ *
+ */
+public class DataPointUsageStatistics {
+    
+    private String dataSourceType;
+    private Integer count;
+    
+    /**
+     * @return the dataSourceType
+     */
+    public String getDataSourceType() {
+        return dataSourceType;
+    }
+    /**
+     * @param dataSourceType the dataSourceType to set
+     */
+    public void setDataSourceType(String dataSourceType) {
+        this.dataSourceType = dataSourceType;
+    }
+    /**
+     * @return the count
+     */
+    public Integer getCount() {
+        return count;
+    }
+    /**
+     * @param count the count to set
+     */
+    public void setCount(Integer count) {
+        this.count = count;
+    }
+    
+    
+
+}

--- a/Core/src/com/infiniteautomation/mango/util/usage/DataSourceUsageStatistics.java
+++ b/Core/src/com/infiniteautomation/mango/util/usage/DataSourceUsageStatistics.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2019  Infinite Automation Software. All rights reserved.
+ */
+package com.infiniteautomation.mango.util.usage;
+
+/**
+ * Statistics about how Data Sources are used in this system
+ * 
+ * @author Terry Packer
+ *
+ */
+public class DataSourceUsageStatistics {
+
+    private String dataSourceType;
+    private Integer count;
+    
+    /**
+     * @return the dataSourceType
+     */
+    public String getDataSourceType() {
+        return dataSourceType;
+    }
+    /**
+     * @param dataSourceType the dataSourceType to set
+     */
+    public void setDataSourceType(String dataSourceType) {
+        this.dataSourceType = dataSourceType;
+    }
+    /**
+     * @return the count
+     */
+    public Integer getCount() {
+        return count;
+    }
+    /**
+     * @param count the count to set
+     */
+    public void setCount(Integer count) {
+        this.count = count;
+    }
+    
+}

--- a/Core/src/com/serotonin/m2m2/Common.java
+++ b/Core/src/com/serotonin/m2m2/Common.java
@@ -202,10 +202,16 @@ public class Common {
         return Version.forIntegers(version.getMajorVersion(), version.getMinorVersion(), version.getPatchVersion());
     }
 
+    public static final int getLicenseAgreementVersion() {
+        return CoreVersion.INSTANCE.licenseAgreementVersion;
+    }
+    
     private enum CoreVersion {
         INSTANCE();
         final Version version;
-
+        //Track license agreement version to ensure the admin users have accepted the current version of our license
+        final int licenseAgreementVersion = 1;
+        
         CoreVersion() {
             Version version = CompiledCoreVersion.VERSION;
 

--- a/Core/src/com/serotonin/m2m2/IMangoLifecycle.java
+++ b/Core/src/com/serotonin/m2m2/IMangoLifecycle.java
@@ -61,10 +61,10 @@ public interface IMangoLifecycle extends Provider {
 
     /**
      * @param timeout
-     * @param b
+     * @param restart (should Mango restart?)
      * @return
      */
-    Thread scheduleShutdown(long timeout, boolean b, User user);
+    Thread scheduleShutdown(long timeout, boolean restart, User user);
 
     /**
      * @return

--- a/Core/src/com/serotonin/m2m2/db/dao/DataPointDao.java
+++ b/Core/src/com/serotonin/m2m2/db/dao/DataPointDao.java
@@ -63,6 +63,7 @@ import com.infiniteautomation.mango.spring.events.DaoEvent;
 import com.infiniteautomation.mango.spring.events.DaoEventType;
 import com.infiniteautomation.mango.spring.events.DataPointTagsUpdatedEvent;
 import com.infiniteautomation.mango.util.LazyInitSupplier;
+import com.infiniteautomation.mango.util.usage.DataPointUsageStatistics;
 import com.serotonin.ModuleNotLoadedException;
 import com.serotonin.ShouldNeverHappenException;
 import com.serotonin.db.MappedRowCallback;
@@ -687,6 +688,23 @@ public class DataPointDao extends AbstractDao<DataPointVO>{
         return counts;
     }
 
+    /**
+     * Get the count of data points per type of data source
+     * @return
+     */
+    public List<DataPointUsageStatistics> getUsage() {
+        return ejt.query("SELECT ds.dataSourceType, COUNT(ds.dataSourceType) FROM dataPoints as dp LEFT JOIN dataSources ds ON dp.dataSourceId=ds.id GROUP BY ds.dataSourceType", 
+                new RowMapper<DataPointUsageStatistics>() {
+                @Override
+                public DataPointUsageStatistics mapRow(ResultSet rs, int rowNum) throws SQLException {
+                    DataPointUsageStatistics usage = new DataPointUsageStatistics();
+                    usage.setDataSourceType(rs.getString(1));
+                    usage.setCount(rs.getInt(2));
+                    return usage;
+                }
+            });
+    }
+    
     //
     // Data point summaries
     private static final String DATA_POINT_SUMMARY_SELECT = //

--- a/Core/src/com/serotonin/m2m2/db/dao/DataSourceDao.java
+++ b/Core/src/com/serotonin/m2m2/db/dao/DataSourceDao.java
@@ -37,6 +37,7 @@ import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 import com.infiniteautomation.mango.spring.events.DaoEvent;
 import com.infiniteautomation.mango.spring.events.DaoEventType;
 import com.infiniteautomation.mango.util.LazyInitSupplier;
+import com.infiniteautomation.mango.util.usage.DataSourceUsageStatistics;
 import com.serotonin.ModuleNotLoadedException;
 import com.serotonin.ShouldNeverHappenException;
 import com.serotonin.db.pair.IntStringPair;
@@ -355,6 +356,22 @@ public class DataSourceDao<T extends DataSourceVO<?>> extends AbstractDao<T> {
                 String.class, null);
     }
 
+    /**
+     * Get the count of data sources per type
+     * @return
+     */
+    public List<DataSourceUsageStatistics> getUsage() {
+        return ejt.query("SELECT dataSourceType, COUNT(dataSourceType) FROM dataSources GROUP BY dataSourceType", new RowMapper<DataSourceUsageStatistics>() {
+            @Override
+            public DataSourceUsageStatistics mapRow(ResultSet rs, int rowNum) throws SQLException {
+                DataSourceUsageStatistics usage = new DataSourceUsageStatistics();
+                usage.setDataSourceType(rs.getString(1));
+                usage.setCount(rs.getInt(2));
+                return usage;
+            }
+        });
+    }
+    
     /*
      * (non-Javadoc)
      *

--- a/Core/src/com/serotonin/m2m2/db/dao/SystemSettingsDao.java
+++ b/Core/src/com/serotonin/m2m2/db/dao/SystemSettingsDao.java
@@ -199,6 +199,9 @@ public class SystemSettingsDao extends BaseDao {
     //Check Store for Upgrades
     public static final String UPGRADE_CHECKS_ENABLED = "upgradeChecksEnabled";
     
+    //License Agreement Acceptance Tracking
+    public static final String LICENSE_AGREEMENT_VERSION = "licenseAgreementVersion";
+    
     public static SystemSettingsDao instance = new SystemSettingsDao();
 
     private final ThreadPoolSettingsListenerDefinition threadPoolListener;
@@ -506,8 +509,9 @@ public class SystemSettingsDao extends BaseDao {
         DEFAULT_VALUES.put(PASSWORD_EXPIRATION_PERIOD_TYPE, Common.TimePeriods.MONTHS);
         DEFAULT_VALUES.put(PASSWORD_EXPIRATION_PERIODS, 6);
 
-        DEFAULT_VALUES.put(USAGE_TRACKING_ENABLED, true);
+        DEFAULT_VALUES.put(USAGE_TRACKING_ENABLED, false);
         DEFAULT_VALUES.put(UPGRADE_CHECKS_ENABLED, true);
+        DEFAULT_VALUES.put(LICENSE_AGREEMENT_VERSION, 0);
 
         // Add module audit event type defaults
         for (AuditEventTypeDefinition def : ModuleRegistry.getDefinitions(AuditEventTypeDefinition.class)) {
@@ -937,6 +941,11 @@ public class SystemSettingsDao extends BaseDao {
         Integer passwordExpirationPeriods = getIntValue(PASSWORD_EXPIRATION_PERIODS, settings);
         if(passwordExpirationPeriods != null && passwordExpirationPeriods < 1)
             response.addContextualMessage(PASSWORD_EXPIRATION_PERIODS, "validate.greaterThanZero");
+        
+        setting = settings.get(LICENSE_AGREEMENT_VERSION);
+        if(setting != null)
+            response.addContextualMessage(LICENSE_AGREEMENT_VERSION, "validate.readOnly");
+
     }
 
 

--- a/Core/src/com/serotonin/m2m2/db/dao/SystemSettingsDao.java
+++ b/Core/src/com/serotonin/m2m2/db/dao/SystemSettingsDao.java
@@ -193,6 +193,12 @@ public class SystemSettingsDao extends BaseDao {
     public static final String PASSWORD_EXPIRATION_PERIOD_TYPE = "passwordExpirationPeriodType";
     public static final String PASSWORD_EXPIRATION_PERIODS = "passwordExpirationPeriods";
 
+    //Usage tracking statistics uploading
+    public static final String USAGE_TRACKING_ENABLED = "usageTrackingEnabled";
+    
+    //Check Store for Upgrades
+    public static final String UPGRADE_CHECKS_ENABLED = "upgradeChecksEnabled";
+    
     public static SystemSettingsDao instance = new SystemSettingsDao();
 
     private final ThreadPoolSettingsListenerDefinition threadPoolListener;
@@ -500,6 +506,8 @@ public class SystemSettingsDao extends BaseDao {
         DEFAULT_VALUES.put(PASSWORD_EXPIRATION_PERIOD_TYPE, Common.TimePeriods.MONTHS);
         DEFAULT_VALUES.put(PASSWORD_EXPIRATION_PERIODS, 6);
 
+        DEFAULT_VALUES.put(USAGE_TRACKING_ENABLED, true);
+        DEFAULT_VALUES.put(UPGRADE_CHECKS_ENABLED, true);
 
         // Add module audit event type defaults
         for (AuditEventTypeDefinition def : ModuleRegistry.getDefinitions(AuditEventTypeDefinition.class)) {

--- a/Core/src/com/serotonin/m2m2/web/dwr/ModulesDwr.java
+++ b/Core/src/com/serotonin/m2m2/web/dwr/ModulesDwr.java
@@ -326,13 +326,8 @@ public class ModulesDwr extends BaseDwr implements ModuleNotificationListener {
 
     public static JsonValue getAvailableUpgrades() throws JsonException, IOException, HttpException {
 
-        //Don't run if we know the admin User has not had a chance to confirm they want this to happen
-        User admin = UserDao.getInstance().getUser("admin");
-        if(admin.getLastLogin() == 0)
-            return null;
-        
         //If upgrade checks are not enabled we won't contact the store at all
-        if(!SystemSettingsDao.instance.getBooleanValue(SystemSettingsDao.UPGRADE_CHECKS_ENABLED, true))
+        if(!SystemSettingsDao.instance.getBooleanValue(SystemSettingsDao.UPGRADE_CHECKS_ENABLED))
             return null;
         
         // Create the request
@@ -380,12 +375,17 @@ public class ModulesDwr extends BaseDwr implements ModuleNotificationListener {
                 jsonModules.put(module.getName(), module.getVersion().toString());
 
         //Optionally Add Usage Data Check if first login for admin has happened to ensure they have 
-        if(SystemSettingsDao.instance.getBooleanValue(SystemSettingsDao.USAGE_TRACKING_ENABLED, true)) {
+        if(SystemSettingsDao.instance.getBooleanValue(SystemSettingsDao.USAGE_TRACKING_ENABLED)) {
             //Collect statistics
             List<DataSourceUsageStatistics> dataSourceCounts =  DataSourceDao.getInstance().getUsage();
             json.put("dataSourcesUsage", dataSourceCounts);
             List<DataPointUsageStatistics> dataPointCounts = DataPointDao.getInstance().getUsage();
             json.put("dataPointsUsage", dataPointCounts);
+            json.put("userCount", UserDao.getInstance().count());
+            json.put("cpuCount", Runtime.getRuntime().availableProcessors());
+            Runtime rt = Runtime.getRuntime();
+            json.put("maxMemoryMB", (int)(rt.maxMemory()/(1024*1024)));
+            
         }
 
         

--- a/Core/src/com/serotonin/m2m2/web/dwr/ModulesDwr.java
+++ b/Core/src/com/serotonin/m2m2/web/dwr/ModulesDwr.java
@@ -31,6 +31,8 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 
 import com.github.zafarkhaja.semver.Version;
+import com.infiniteautomation.mango.util.usage.DataPointUsageStatistics;
+import com.infiniteautomation.mango.util.usage.DataSourceUsageStatistics;
 import com.serotonin.ShouldNeverHappenException;
 import com.serotonin.db.pair.StringStringPair;
 import com.serotonin.json.JsonException;
@@ -45,7 +47,10 @@ import com.serotonin.m2m2.Constants;
 import com.serotonin.m2m2.ICoreLicense;
 import com.serotonin.m2m2.IMangoLifecycle;
 import com.serotonin.m2m2.UpgradeVersionState;
+import com.serotonin.m2m2.db.dao.DataPointDao;
+import com.serotonin.m2m2.db.dao.DataSourceDao;
 import com.serotonin.m2m2.db.dao.SystemSettingsDao;
+import com.serotonin.m2m2.db.dao.UserDao;
 import com.serotonin.m2m2.i18n.ProcessResult;
 import com.serotonin.m2m2.i18n.TranslatableMessage;
 import com.serotonin.m2m2.i18n.Translations;
@@ -320,6 +325,16 @@ public class ModulesDwr extends BaseDwr implements ModuleNotificationListener {
     }
 
     public static JsonValue getAvailableUpgrades() throws JsonException, IOException, HttpException {
+
+        //Don't run if we know the admin User has not had a chance to confirm they want this to happen
+        User admin = UserDao.getInstance().getUser("admin");
+        if(admin.getLastLogin() == 0)
+            return null;
+        
+        //If upgrade checks are not enabled we won't contact the store at all
+        if(!SystemSettingsDao.instance.getBooleanValue(SystemSettingsDao.UPGRADE_CHECKS_ENABLED, true))
+            return null;
+        
         // Create the request
         List<Module> modules = ModuleRegistry.getModules();
         Module.sortByName(modules);
@@ -364,6 +379,16 @@ public class ModulesDwr extends BaseDwr implements ModuleNotificationListener {
             if (!module.isMarkedForDeletion())
                 jsonModules.put(module.getName(), module.getVersion().toString());
 
+        //Optionally Add Usage Data Check if first login for admin has happened to ensure they have 
+        if(SystemSettingsDao.instance.getBooleanValue(SystemSettingsDao.USAGE_TRACKING_ENABLED, true)) {
+            //Collect statistics
+            List<DataSourceUsageStatistics> dataSourceCounts =  DataSourceDao.getInstance().getUsage();
+            json.put("dataSourcesUsage", dataSourceCounts);
+            List<DataPointUsageStatistics> dataPointCounts = DataPointDao.getInstance().getUsage();
+            json.put("dataPointsUsage", dataPointCounts);
+        }
+
+        
         StringWriter stringWriter = new StringWriter();
         new JsonWriter(Common.JSON_CONTEXT, stringWriter).writeObject(json);
         String requestData = stringWriter.toString();


### PR DESCRIPTION
I combined the upgrade check with the option to add usage data so we can leverage the same store controller to pull out and store that information.  

This means there are 2 new system settings.  One that allows disabling the upgrade check entirely, which means if you don't check for upgrades you won't supply usage data.  The other for disabling suppling usage data if you are checking for upgrades.

I think there is more information we may want to collect but this is a start.