### PR TITLE
Data source shutdown performance

### DIFF
--- a/Core/src/com/infiniteautomation/mango/spring/service/MailingListService.java
+++ b/Core/src/com/infiniteautomation/mango/spring/service/MailingListService.java
@@ -15,9 +15,13 @@ import java.util.Set;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.infiniteautomation.mango.spring.db.MailingListTableDefinition;
+import com.infiniteautomation.mango.spring.events.DaoEvent;
 import com.serotonin.m2m2.Common;
 import com.serotonin.m2m2.db.dao.MailingListDao;
 import com.serotonin.m2m2.db.dao.UserDao;
@@ -46,12 +50,15 @@ public class MailingListService extends AbstractVOService<MailingList, MailingLi
 
     private final UserDao userDao;
     private final MailingListCreatePermission createPermission;
+    private final Cache<Integer, MailingList> cache;
 
     @Autowired
     public MailingListService(MailingListDao dao, PermissionService permissionService, UserDao userDao, MailingListCreatePermission createPermission) {
         super(dao, permissionService);
         this.userDao = userDao;
         this.createPermission = createPermission;
+        this.cache = Caffeine.newBuilder().build();
+        this.dao.getAll().stream().forEach(ml -> this.cache.put(ml.getId(), ml));
     }
 
     /**
@@ -67,13 +74,13 @@ public class MailingListService extends AbstractVOService<MailingList, MailingLi
         this.permissionService.ensureAdminRole(user);
 
         List<MailingList> result = new ArrayList<>();
-        dao.doInTransaction((status) -> {
-            dao.customizedQuery(dao.getJoinedSelectQuery().where(
-                    dao.getTable().getAlias("receiveAlarmEmails").greaterOrEqual(0),
-                    dao.getTable().getAlias("receiveAlarmEmails").lessOrEqual(alarmLevel.value())), (value, index) -> {
-                        result.add(value);
-                    });
+
+        cache.asMap().forEach((id, ml) -> {
+            if(ml.getReceiveAlarmEmails().value() >= 0 && ml.getReceiveAlarmEmails().value() <= alarmLevel.value()) {
+                result.add(ml);
+            }
         });
+
         Set<String> addresses = new HashSet<>();
         for(MailingList list : result) {
             addresses.addAll(getActiveRecipients(list.getEntries(), time, types));
@@ -382,5 +389,24 @@ public class MailingListService extends AbstractVOService<MailingList, MailingLi
         interval += dt.getHour() * 4;
         interval += (dt.getDayOfWeek().getValue() - 1) * 96;
         return interval;
+    }
+
+    /**
+     * Keep our cache up to date by evicting changed roles
+     * @param event
+     */
+    @EventListener
+    protected void handleMailingListEvent(DaoEvent<? extends MailingList> event) {
+        switch(event.getType()) {
+            case DELETE:
+                this.cache.invalidate(event.getVo().getId());
+                break;
+            case UPDATE:
+            case CREATE:
+                this.cache.put(event.getVo().getId(), event.getVo());
+                break;
+            default:
+                break;
+        }
     }
 }

--- a/Core/src/com/serotonin/m2m2/rt/EventManager.java
+++ b/Core/src/com/serotonin/m2m2/rt/EventManager.java
@@ -104,7 +104,17 @@ public interface EventManager extends ILifecycle{
     //
     // Canceling events.
     //
+    /**
+     * Cancel active events for a Data Point
+     * @param dataPointId
+     */
     void cancelEventsForDataPoint(int dataPointId);
+
+    /**
+     * Cancel active events for these Data Points
+     * @param pointIds
+     */
+    void cancelEventsForDataPoints(List<Integer> pointIds);
 
     /**
      * Cancel active events for a Data Source

--- a/Core/src/com/serotonin/m2m2/rt/RuntimeManagerImpl.java
+++ b/Core/src/com/serotonin/m2m2/rt/RuntimeManagerImpl.java
@@ -20,7 +20,6 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.util.Assert;
 
 import com.serotonin.ShouldNeverHappenException;
-import com.serotonin.log.LogStopWatch;
 import com.serotonin.m2m2.Common;
 import com.serotonin.m2m2.db.dao.DataPointDao;
 import com.serotonin.m2m2.db.dao.DataSourceDao;
@@ -448,11 +447,9 @@ public class RuntimeManagerImpl implements RuntimeManager {
         if (dataSource == null)
             return;
         try{
-            LogStopWatch log = new LogStopWatch();
-
+            long now = Common.timer.currentTimeMillis();
             //Signal we are going down
             dataSource.terminating();
-            log.logInfo("Terminating down data source.", 0);
 
             List<Integer> pointIds = new ArrayList<>();
             // Stop the data points.
@@ -469,12 +466,9 @@ public class RuntimeManagerImpl implements RuntimeManager {
             synchronized (runningDataSources) {
                 runningDataSources.remove(dataSource.getId());
             }
-            log.logInfo("Terminated data points.", 0);
             dataSource.terminate();
-            log.logInfo("Terminated data source.", 0);
             dataSource.joinTermination();
-            log.logInfo("Joine Terminated data source.", 0);
-            LOG.info("Data source '" + dataSource.getName() + "' stopped");
+            LOG.info("Data source '" + dataSource.getName() + "' stopped in " + (Common.timer.currentTimeMillis() - now) + "ms");
         }catch(Exception e){
             LOG.error("Data source '" + dataSource.getName() + "' failed proper termination.", e);
         }

--- a/Core/src/com/serotonin/m2m2/rt/dataImage/DataPointRT.java
+++ b/Core/src/com/serotonin/m2m2/rt/dataImage/DataPointRT.java
@@ -888,7 +888,6 @@ public class DataPointRT implements IDataPointValueSource, ILifecycle {
                 pedRT.terminate();
             }
         }
-        Common.eventManager.cancelEventsForDataPoint(vo.getId());
     }
 
     @Override


### PR DESCRIPTION
This improves shutdown performance of data sources with many active events.

On a data source with 20k data points with 20k active events the shutdown time was improved from 73,967ms to 1,926ms.  

The general performance of events being raised is also improved by caching the MailingLists which are accessed every time an event is raised as per #1639.