### PR TITLE
Backport fix for RAD-1362

### DIFF
--- a/Core/src/com/serotonin/m2m2/email/UsedImagesDirective.java
+++ b/Core/src/com/serotonin/m2m2/email/UsedImagesDirective.java
@@ -39,8 +39,8 @@ public class UsedImagesDirective implements TemplateDirectiveModel {
             if (Boolean.parseBoolean(s)) {
                 writeLogo = true;
 
-                if (!imageList.contains(Common.APPLICATION_LOGO))
-                    imageList.add(Common.APPLICATION_LOGO);
+                if (!imageList.contains("." + Common.APPLICATION_LOGO))
+                    imageList.add("." + Common.APPLICATION_LOGO);
                 env.getOut().write(Common.APPLICATION_LOGO);
             }
         }


### PR DESCRIPTION
Needs to be tested but I think this is a simple fix for 4.2. The image list is resolved against Common.WEB like so -
```
for (String s : inlineImages.getImageList())
                content.addInline(new FileInline(s, Common.WEB.resolve(s).toFile()));
```
So this should prevent it resulting in an absolute path.
